### PR TITLE
Fix #4. DONT MERGE until sure you DONT discard init run

### DIFF
--- a/src/benchmarker/Benchmarker.jl
+++ b/src/benchmarker/Benchmarker.jl
@@ -31,14 +31,10 @@ module Benchmarker
 	function measure(iters, f, args...)
 		timings = Array{Float64}(undef, iters)
 
-		# Compile f and let JIT optimize f
-		#for _ in 1:10
-			@elapsed f(map(copy, args)...)
-		#end
-
+    # JIT optimization run removed. Postprocessing will handle JIT-ed runs
 		local elapsed_time::Float64 = 0.0
 		for i=1:iters
-            copy_args = map(copy, args)
+      copy_args = map(copy, args)
 			cachescrub()
 			gcscrub()
 			elapsed_time = @elapsed f(copy_args...)

--- a/src/benchmarker/Plot.jl
+++ b/src/benchmarker/Plot.jl
@@ -24,7 +24,8 @@ function add_data(p::Plot, extra_data::Array{P, 1}, timings::Results) where P
   data = isempty(extra_data) ? t : [reshape(extra_data, (1, :)) t]
   writedlm(p.file, data, p.delimiter)
 
-  writedlm(p.file_timings, transpose(timings.timings), p.delimiter)
+  data = isempty(extra_data) ? transpose(timings.timings) : [reshape(extra_data, (1, :)) transpose(timings.timings)]
+  writedlm(p.file_timings, data, p.delimiter)
 end
 
 function finish(p::Plot)


### PR DESCRIPTION
We want to record the timings for the JIT warm-up runs. 